### PR TITLE
Rename some packages as newer rust doesn't allow starting names with a digit. 

### DIFF
--- a/02-hello-world/Cargo.toml
+++ b/02-hello-world/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "02-hello-world"
+name = "hello-world"
 version = "0.1.0"
 edition = "2018"
 

--- a/03-generating-bindings/Cargo.toml
+++ b/03-generating-bindings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "03-generating-bindings"
+name = "generating-bindings"
 version = "0.1.0"
 edition = "2018"
 

--- a/04-safe-framework/Cargo.toml
+++ b/04-safe-framework/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "04-safe-framework"
+name = "safe-framework"
 version = "0.1.0"
 edition = "2018"
 

--- a/05-creating-devices/Cargo.toml
+++ b/05-creating-devices/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "05-creating-devices"
+name = "creating-devices"
 version = "0.1.0"
 edition = "2018"
 

--- a/06-reading-and-writing/Cargo.toml
+++ b/06-reading-and-writing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "06-reading-and-writing"
+name = "reading-and-writing"
 version = "0.1.0"
 edition = "2018"
 

--- a/07-io-controls/Cargo.toml
+++ b/07-io-controls/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "07-io-controls"
+name = "io-controls"
 version = "0.1.0"
 edition = "2018"
 

--- a/user/05-creating-devices/Cargo.toml
+++ b/user/05-creating-devices/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
-name = "user-05-creating-devices"
+name = "user-creating-devices"
 version = "0.1.0"
 edition = "2018"

--- a/user/06-reading-and-writing/Cargo.toml
+++ b/user/06-reading-and-writing/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
-name = "user-06-reading-and-writing"
+name = "user-reading-and-writing"
 version = "0.1.0"
 edition = "2018"

--- a/user/07-io-controls/Cargo.toml
+++ b/user/07-io-controls/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "user-07-io-controls"
+name = "user-io-controls"
 version = "0.1.0"
 edition = "2018"
 


### PR DESCRIPTION
Newer rust versions specify that package names cannot start with a digit. This pull request simply renames them to remove the digit. If the maintainer would prefer, the digits can be readded as a suffix. 